### PR TITLE
Write unit tests for Actions

### DIFF
--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -32,13 +32,9 @@ function runAction<A extends Action>(
 describe('InsertAction', () => {
   it('adds environment at point', () => {
     const input = '$$|$$';
-    const expected = [
-      '$$',
-      '\\begin{equation}',
-      '|',
-      '\\end{equation}',
-      '$$',
-    ].join('\n');
+    const expected = ['$$\\begin{equation}', '|', '\\end{equation}$$'].join(
+      '\n',
+    );
     const { value, cursor } = valueAndCursor(expected);
     const doc = runAction(input, InsertAction);
     expect(doc.getValue()).toBe(value);
@@ -59,15 +55,13 @@ describe('InsertAction', () => {
     expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
   });
 
-  it('adds newlines to separate from adjacent content', () => {
+  it("doesn't add newlines to separate from adjacent content", () => {
     const input = ['$$', 'x^2 + 1| - 2', '$$'].join('\n');
     const expected = [
       '$$',
-      'x^2 + 1',
-      '\\begin{equation}',
+      'x^2 + 1\\begin{equation}',
       '|',
-      '\\end{equation}',
-      ' - 2',
+      '\\end{equation} - 2',
       '$$',
     ].join('\n');
     const { value, cursor } = valueAndCursor(expected);
@@ -79,8 +73,7 @@ describe('InsertAction', () => {
     const input = ['$$', 'x^2 + 1|', '$$'].join('\n');
     const expected = [
       '$$',
-      'x^2 + 1',
-      '\\begin{equation}',
+      'x^2 + 1\\begin{equation}',
       '|',
       '\\end{equation}',
       '$$',
@@ -96,8 +89,7 @@ describe('InsertAction', () => {
       '$$',
       '\\begin{equation}',
       '|',
-      '\\end{equation}',
-      'x^2 + 1',
+      '\\end{equation}x^2 + 1',
       '$$',
     ].join('\n');
     const { value, cursor } = valueAndCursor(expected);
@@ -193,7 +185,7 @@ describe('DeleteAction', () => {
       '\n',
     );
 
-    const expected = ['$$', '|x^2 + 1', '$$'].join('\n');
+    const expected = '$$|x^2 + 1$$';
 
     const { value, cursor } = valueAndCursor(expected);
     const doc = runAction(input, DeleteAction);
@@ -220,13 +212,11 @@ describe('DeleteAction', () => {
       '\\end{gather}$$',
     ].join('\n');
     const expected = [
-      '$$',
-      'x^2|=2\\\\',
+      '$$x^2|=2\\\\',
       '\\begin{pmatrix}',
       '1&2\\\\',
       '3&4',
-      '\\end{pmatrix}',
-      '$$',
+      '\\end{pmatrix}$$',
     ].join('\n');
 
     const { value, cursor } = valueAndCursor(expected);
@@ -245,10 +235,8 @@ describe('DeleteAction', () => {
     ].join('\n');
     const expected = [
       '$$\\begin{equation}',
-      '',
       'x^2|=2\\\\',
       'y^2=3',
-      '',
       '\\end{equation}$$',
     ].join('\n');
 

--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -1,0 +1,260 @@
+import { InsertAction } from '../src/actions/insertAction';
+import { ChangeAction } from '../src/actions/changeAction';
+import { DeleteAction } from '../src/actions/deleteAction';
+import { Action } from '../src/actions/action';
+import { EditorView } from '@codemirror/view';
+import { TestEditor } from './testEditor';
+import { fromString, valueAndCursor } from './testHelpers';
+import { EditorLike } from '../src/editorLike';
+
+function runAction<A extends Action>(
+  input: string,
+  ActionType: new (doc: EditorLike) => A,
+  envName = 'equation',
+): EditorLike {
+  const doc = fromString(input);
+
+  const view = new EditorView();
+  const editor = new TestEditor(view);
+
+  editor.setValue(doc.text);
+  editor.setCursor(doc.cursor);
+  editor.setSelection(doc.selection.from, doc.selection.to);
+
+  const action = new ActionType(editor).prepare();
+  const tx = action.transaction(envName);
+  editor.transaction(tx);
+  return editor;
+}
+
+// | indicates the location of the cursor
+
+describe('InsertAction', () => {
+  it('adds environment at point', () => {
+    const input = '$$|$$';
+    const expected = [
+      '$$',
+      '\\begin{equation}',
+      '|',
+      '\\end{equation}',
+      '$$',
+    ].join('\n');
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, InsertAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+  it('wraps the selection with an environment', () => {
+    const input = '$$|x^2 + 1|$$';
+    const expected = [
+      '$$\\begin{equation}',
+      '|x^2 + 1',
+      '\\end{equation}$$',
+    ].join('\n');
+
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, InsertAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.somethingSelected()).toBeFalsy();
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+
+  it('adds newlines to separate from adjacent content', () => {
+    const input = ['$$', 'x^2 + 1| - 2', '$$'].join('\n');
+    const expected = [
+      '$$',
+      'x^2 + 1',
+      '\\begin{equation}',
+      '|',
+      '\\end{equation}',
+      ' - 2',
+      '$$',
+    ].join('\n');
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, InsertAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+  it("doesn't add a newline after when all white space after the cursor", () => {
+    const input = ['$$', 'x^2 + 1|', '$$'].join('\n');
+    const expected = [
+      '$$',
+      'x^2 + 1',
+      '\\begin{equation}',
+      '|',
+      '\\end{equation}',
+      '$$',
+    ].join('\n');
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, InsertAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+  it("doesn't add a newline before when all white space before the cursor", () => {
+    const input = ['$$', '|x^2 + 1', '$$'].join('\n');
+    const expected = [
+      '$$',
+      '\\begin{equation}',
+      '|',
+      '\\end{equation}',
+      'x^2 + 1',
+      '$$',
+    ].join('\n');
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, InsertAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+  it("doesn't add newlines if insert line is blank", () => {
+    const input = ['$$', '|', '$$'].join('\n');
+    const expected = [
+      '$$',
+      '\\begin{equation}',
+      '|',
+      '\\end{equation}',
+      '$$',
+    ].join('\n');
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, InsertAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+});
+describe('ChangeAction', () => {
+  it('changes the name of surrounding environment', () => {
+    const input = ['$$\\begin{equation}', '|', '\\end{equation}$$'].join('\n');
+    const expected = ['$$\\begin{multline}', '|', '\\end{multline}$$'].join(
+      '\n',
+    );
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, ChangeAction, 'multline');
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+
+  it('when no surrounding environment wraps the whole block', () => {
+    const input = '$$|x^2 + 1$$';
+    const expected = [
+      '$$\\begin{equation}',
+      '|x^2 + 1',
+      '\\end{equation}$$',
+    ].join('\n');
+
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, ChangeAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+
+  it('wraps the whole block when not enclosed and after another environment', () => {
+    const input = [
+      '$$',
+      'x^2 + 1',
+      '= \\begin{pmatrix}',
+      '1 & 0',
+      '\\end{pmatrix}',
+      '| - 3',
+      '$$',
+    ].join('\n');
+    const expected = [
+      '$$\\begin{equation}',
+      'x^2 + 1',
+      '= \\begin{pmatrix}',
+      '1 & 0',
+      '\\end{pmatrix}',
+      '| - 3',
+      '\\end{equation}$$',
+    ].join('\n');
+
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, ChangeAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+
+  it("doesn't add whitespace when no enclosing environment", () => {
+    const input = ['$$', '|x^2 + 1', '$$'].join('\n');
+    const expected = [
+      '$$\\begin{equation}',
+      '|x^2 + 1',
+      '\\end{equation}$$',
+    ].join('\n');
+
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, ChangeAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+});
+
+describe('DeleteAction', () => {
+  it('removes the begin and end of surrounding environment', () => {
+    const input = ['$$\\begin{equation}', '|x^2 + 1', '\\end{equation}$$'].join(
+      '\n',
+    );
+
+    const expected = ['$$', '|x^2 + 1', '$$'].join('\n');
+
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, DeleteAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+
+  it('is a noop for no surrounding environments', () => {
+    const input = ['$$', '|x^2 + 1', '$$'].join('\n');
+
+    const { value, cursor } = valueAndCursor(input);
+    const doc = runAction(input, DeleteAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+  it('leaves adjacent environments untouched', () => {
+    const input = [
+      '$$\\begin{gather}',
+      'x^2|=2\\\\',
+      '\\begin{pmatrix}',
+      '1&2\\\\',
+      '3&4',
+      '\\end{pmatrix}',
+      '\\end{gather}$$',
+    ].join('\n');
+    const expected = [
+      '$$',
+      'x^2|=2\\\\',
+      '\\begin{pmatrix}',
+      '1&2\\\\',
+      '3&4',
+      '\\end{pmatrix}',
+      '$$',
+    ].join('\n');
+
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, DeleteAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+  it('only deletes nearest enclosing environment', () => {
+    const input = [
+      '$$\\begin{equation}',
+      '\\begin{gathered}',
+      'x^2|=2\\\\',
+      'y^2=3',
+      '\\end{gathered}',
+      '\\end{equation}$$',
+    ].join('\n');
+    const expected = [
+      '$$\\begin{equation}',
+      '',
+      'x^2|=2\\\\',
+      'y^2=3',
+      '',
+      '\\end{equation}$$',
+    ].join('\n');
+
+    const { value, cursor } = valueAndCursor(expected);
+    const doc = runAction(input, DeleteAction);
+    expect(doc.getValue()).toBe(value);
+    expect(doc.getCursor()).toStrictEqual(expect.objectContaining(cursor));
+  });
+});

--- a/__tests__/testEditor.ts
+++ b/__tests__/testEditor.ts
@@ -1,0 +1,90 @@
+// Modified from test code by Tim Hor
+// at https://github.com/timhor/obsidian-editor-shortcuts/blob/0f364c444311efe2f880867033ee94475941e725/src/__tests__/test-helpers.ts
+// used under the MIT license.
+import { EditorState, Text, SelectionRange } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import type { EditorPosition, EditorTransaction } from 'obsidian';
+import { EditorLike } from '../src/editorLike';
+
+function isDefined<T>(val: T | undefined | null): val is T {
+  return val !== undefined && val !== null;
+}
+
+// Light wrapper around EditorView to allow testing actions.
+// Based on the migration guide at https://codemirror.net/docs/migration/
+export class TestEditor implements EditorLike {
+  constructor(private readonly view: EditorView) {}
+
+  private doc(): Text {
+    return this.view.state.doc;
+  }
+
+  getCursor(): EditorPosition {
+    const offset = this.view.state.selection.main.head;
+    return this.offsetToPos(offset);
+  }
+
+  setCursor(pos: number): void {
+    return this.view.dispatch({ selection: { anchor: pos } });
+  }
+
+  getSelection(): string {
+    return this.view.state.sliceDoc(
+      this.view.state.selection.main.from,
+      this.view.state.selection.main.to,
+    );
+  }
+
+  setSelection(from: number, to: number): void {
+    return this.view.dispatch({ selection: { anchor: from, head: to } });
+  }
+
+  getValue(): string {
+    return this.doc().toString();
+  }
+
+  setValue(value: string): void {
+    this.view.setState(EditorState.create({ doc: value }));
+  }
+
+  posToOffset(pos: EditorPosition): number {
+    return this.doc().line(pos.line + 1).from + pos.ch;
+  }
+
+  offsetToPos(offset: number): { ch: number; line: number } {
+    const line = this.doc().lineAt(offset);
+    return { line: line.number - 1, ch: offset - line.from };
+  }
+
+  somethingSelected(): Boolean {
+    return this.view.state.selection.ranges.some(
+      (r: SelectionRange) => !r.empty,
+    );
+  }
+
+  focus(): void {
+    this.view.focus();
+  }
+
+  transaction(editorTransaction: EditorTransaction): void {
+    const changes = editorTransaction.changes?.map((change) => {
+      const to = isDefined(change.to) ? this.posToOffset(change.to) : undefined;
+      return {
+        from: this.posToOffset(change.from),
+        to,
+        insert: change.text,
+      };
+    });
+
+    let selection;
+    if (isDefined(editorTransaction.selection)) {
+      const { from, to } = editorTransaction.selection;
+      const head = isDefined(to) ? this.posToOffset(to) : undefined;
+      selection = {
+        anchor: this.posToOffset(from),
+        head,
+      };
+    }
+    this.view.dispatch({ changes, selection });
+  }
+}

--- a/__tests__/testHelpers.ts
+++ b/__tests__/testHelpers.ts
@@ -1,4 +1,5 @@
 import { PosRange } from '../src/environment';
+import { EditorPosition } from 'obsidian';
 
 export interface DocInfo {
   text: string;
@@ -18,33 +19,33 @@ export function fromString(template: string): DocInfo {
     },
   };
 }
-//
-// export function allCursorsFromString(str: string): CodeMirror.Position[] {
-//   const cursors = [];
-//   const lines = str.split('\n');
-//   for (let i = 0; i < lines.length; i++) {
-//     const ch = lines[i].indexOf('|');
-//     if (ch !== -1) {
-//       cursors.push({ ch: ch, line: i });
-//     }
-//   }
-//   return cursors;
-// }
-//
-// export function cursorFromString(str: string): CodeMirror.Position {
-//   const cursor = allCursorsFromString(str).shift();
-//   if (cursor === undefined) {
-//     return { ch: -1, line: -1 };
-//   }
-//   return cursor;
-// }
-//
-// export function valueAndCursor(str: string): {
-//   value: string;
-//   cursor: CodeMirror.Position;
-// } {
-//   return {
-//     value: str.replace('|', ''),
-//     cursor: cursorFromString(str),
-//   };
-// }
+
+export function allCursorsFromString(str: string): EditorPosition[] {
+  const cursors = [];
+  const lines = str.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const ch = lines[i].indexOf('|');
+    if (ch !== -1) {
+      cursors.push({ ch: ch, line: i });
+    }
+  }
+  return cursors;
+}
+
+export function cursorFromString(str: string): EditorPosition {
+  const cursor = allCursorsFromString(str).shift();
+  if (cursor === undefined) {
+    return { ch: -1, line: -1 };
+  }
+  return cursor;
+}
+
+export function valueAndCursor(str: string): {
+  value: string;
+  cursor: EditorPosition;
+} {
+  return {
+    value: str.replace('|', ''),
+    cursor: cursorFromString(str),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "url": "git@github.com:raineszm/obsidian-latex-environments.git"
   },
   "devDependencies": {
+    "@codemirror/state": "^6.2.1",
+    "@codemirror/view": "^6.14.0",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@types/jest": "^26.0.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@codemirror/state':
+    specifier: ^6.2.1
+    version: 6.2.1
+  '@codemirror/view':
+    specifier: ^6.14.0
+    version: 6.14.0
   '@commitlint/cli':
     specifier: ^11.0.0
     version: 11.0.0
@@ -427,6 +433,18 @@ packages:
     dependencies:
       exec-sh: 0.3.6
       minimist: 1.2.8
+    dev: true
+
+  /@codemirror/state@6.2.1:
+    resolution: {integrity: sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw==}
+    dev: true
+
+  /@codemirror/view@6.14.0:
+    resolution: {integrity: sha512-I263FPs4In42MNmrdwN2DfmYPFMVMXgT7o/mxdGp4jv5LPs8i0FOxzmxF5yeeQdYSTztb2ZhmPIu0ahveInVTg==}
+    dependencies:
+      '@codemirror/state': 6.2.1
+      style-mod: 4.0.3
+      w3c-keyname: 2.2.8
     dev: true
 
   /@commitlint/cli@11.0.0:
@@ -5781,6 +5799,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /style-mod@4.0.3:
+    resolution: {integrity: sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw==}
+    dev: true
+
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -6164,6 +6186,10 @@ packages:
     deprecated: Use your platform's native performance.now() and performance.timeOrigin.
     dependencies:
       browser-process-hrtime: 1.0.0
+    dev: true
+
+  /w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
     dev: true
 
   /w3c-xmlserializer@2.0.0:

--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -1,7 +1,8 @@
-import { Editor, EditorTransaction } from 'obsidian';
+import { EditorTransaction } from 'obsidian';
+import { EditorLike } from '../editorLike';
 
 export abstract class Action {
-  constructor(public doc: Editor) {}
+  constructor(public doc: EditorLike) {}
   abstract prepare(): Action;
   abstract transaction(envName: string): EditorTransaction;
   public suggestName(): string | undefined {

--- a/src/actions/wrapAction.ts
+++ b/src/actions/wrapAction.ts
@@ -1,9 +1,10 @@
 import { Action } from './action';
 import { newEnvironment } from '../environment';
-import { Editor, EditorTransaction } from 'obsidian';
+import { EditorTransaction } from 'obsidian';
+import { EditorLike } from '../editorLike';
 
 export class WrapAction extends Action {
-  constructor(doc: Editor, public readonly addWhitespace = true) {
+  constructor(doc: EditorLike, public readonly addWhitespace = true) {
     super(doc);
   }
 

--- a/src/editorLike.ts
+++ b/src/editorLike.ts
@@ -1,4 +1,4 @@
-import { Editor, EditorPosition, EditorTransaction } from 'obsidian';
+import { EditorPosition, EditorTransaction } from 'obsidian';
 
 // We need to shim the Editor class because it's not exported from Obsidian.
 // This allows us to test by using codemirror directly.
@@ -18,39 +18,4 @@ export interface EditorLike {
   transaction: (editorTransaction: EditorTransaction) => void;
 
   focus: () => void;
-}
-
-export class EditorShim implements EditorLike {
-  constructor(private readonly editor: Editor) {}
-  offsetToPos(from: number): EditorPosition {
-    return this.editor.offsetToPos(from);
-  }
-
-  getCursor(): EditorPosition {
-    return this.editor.getCursor();
-  }
-
-  getSelection(): string {
-    return this.editor.getSelection();
-  }
-
-  posToOffset(pos: EditorPosition): number {
-    return this.editor.posToOffset(pos);
-  }
-
-  getValue(): string {
-    return this.editor.getValue();
-  }
-
-  somethingSelected(): Boolean {
-    return this.editor.somethingSelected();
-  }
-
-  transaction(editorTransaction: EditorTransaction): void {
-    this.editor.transaction(editorTransaction);
-  }
-
-  focus(): void {
-    this.editor.focus();
-  }
 }

--- a/src/editorLike.ts
+++ b/src/editorLike.ts
@@ -1,0 +1,56 @@
+import { Editor, EditorPosition, EditorTransaction } from 'obsidian';
+
+// We need to shim the Editor class because it's not exported from Obsidian.
+// This allows us to test by using codemirror directly.
+export interface EditorLike {
+  getCursor: () => EditorPosition;
+
+  getSelection: () => string;
+
+  offsetToPos: (from: number) => EditorPosition;
+
+  posToOffset: (pos: EditorPosition) => number;
+
+  getValue: () => string;
+
+  somethingSelected: () => Boolean;
+
+  transaction: (editorTransaction: EditorTransaction) => void;
+
+  focus: () => void;
+}
+
+export class EditorShim implements EditorLike {
+  constructor(private readonly editor: Editor) {}
+  offsetToPos(from: number): EditorPosition {
+    return this.editor.offsetToPos(from);
+  }
+
+  getCursor(): EditorPosition {
+    return this.editor.getCursor();
+  }
+
+  getSelection(): string {
+    return this.editor.getSelection();
+  }
+
+  posToOffset(pos: EditorPosition): number {
+    return this.editor.posToOffset(pos);
+  }
+
+  getValue(): string {
+    return this.editor.getValue();
+  }
+
+  somethingSelected(): Boolean {
+    return this.editor.somethingSelected();
+  }
+
+  transaction(editorTransaction: EditorTransaction): void {
+    this.editor.transaction(editorTransaction);
+  }
+
+  focus(): void {
+    this.editor.focus();
+  }
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,4 +1,5 @@
-import { Editor, EditorTransaction, EditorPosition } from 'obsidian';
+import { EditorTransaction, EditorPosition } from 'obsidian';
+import { EditorLike } from './editorLike';
 
 export interface PosRange {
   from: number;
@@ -31,7 +32,7 @@ export function newEnvironment(
 
 export function unwrapEnvironment(
   environment: Environment,
-  doc: Editor,
+  doc: EditorLike,
 ): EditorTransaction {
   return {
     changes: [
@@ -47,7 +48,7 @@ export function unwrapEnvironment(
 
 export function changeEnvironment(
   environment: Environment,
-  doc: Editor,
+  doc: EditorLike,
   name: string,
 ): EditorTransaction {
   const change = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { InsertAction } from './actions/insertAction';
 import { ChangeAction } from './actions/changeAction';
 import { Action } from './actions/action';
 import { DeleteAction } from './actions/deleteAction';
+import { EditorLike, EditorShim } from './editorLike';
 
 export default class LatexEnvironments extends Plugin {
   public settings: LatexEnvironmentsSettings = new LatexEnvironmentsSettings();
@@ -38,11 +39,12 @@ export default class LatexEnvironments extends Plugin {
   }
 
   private mathModeCallback<A extends Action>(
-    ActionType: new (doc: Editor) => A,
+    ActionType: new (doc: EditorLike) => A,
   ) {
     return (editor: Editor, _view: MarkdownView) => {
       try {
-        const action = new ActionType(editor.getDoc()).prepare();
+        const doc = new EditorShim(editor);
+        const action = new ActionType(doc).prepare();
         this.withPromptName(editor, action);
       } catch (e: any) {
         /* eslint-disable-next-line no-new */
@@ -51,7 +53,7 @@ export default class LatexEnvironments extends Plugin {
     };
   }
 
-  private withPromptName(editor: Editor, action: Action): void {
+  private withPromptName(editor: EditorLike, action: Action): void {
     const call = (envName: string): void => {
       editor.transaction(action.transaction(envName));
       editor.focus();

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { InsertAction } from './actions/insertAction';
 import { ChangeAction } from './actions/changeAction';
 import { Action } from './actions/action';
 import { DeleteAction } from './actions/deleteAction';
-import { EditorLike, EditorShim } from './editorLike';
+import { EditorLike } from './editorLike';
 
 export default class LatexEnvironments extends Plugin {
   public settings: LatexEnvironmentsSettings = new LatexEnvironmentsSettings();
@@ -43,8 +43,7 @@ export default class LatexEnvironments extends Plugin {
   ) {
     return (editor: Editor, _view: MarkdownView) => {
       try {
-        const doc = new EditorShim(editor);
-        const action = new ActionType(doc).prepare();
+        const action = new ActionType(editor).prepare();
         this.withPromptName(editor, action);
       } catch (e: any) {
         /* eslint-disable-next-line no-new */

--- a/test_vault/ObsidianLatexEnvironments/.obsidian/.gitignore
+++ b/test_vault/ObsidianLatexEnvironments/.obsidian/.gitignore
@@ -1,2 +1,4 @@
 appearance.json
 plugins
+workspace.json
+workspace


### PR DESCRIPTION
When Obsidian introduced live preview, the codemirror functionality was moved behind an abstract class in the interface in order to generalize over Codemirror 5 vs 6 differences. This broke our previous unit tests for the editor actions.

This PR moves editor access behind an interface and implements a test shim over CodeMirror 6 so that we can again do unit testing of `Action`s.